### PR TITLE
Fixes memory leak in render code

### DIFF
--- a/PlayerMarkerModule/Entity/PlayerMarker.cs
+++ b/PlayerMarkerModule/Entity/PlayerMarker.cs
@@ -143,6 +143,8 @@ namespace Tortle.PlayerMarker.Entity
 			_effect.Projection = GameService.Gw2Mumble.PlayerCamera.Projection;
 			_effect.World = worldMatrix;
 			_effect.Alpha = MarkerOpacity;
+
+			// Need to get this texture every time because of the texture swapping underneath when loading.
 			_effect.Texture = MarkerTexture.Get();
 
 

--- a/PlayerMarkerModule/Entity/PlayerMarker.cs
+++ b/PlayerMarkerModule/Entity/PlayerMarker.cs
@@ -10,11 +10,15 @@ namespace Tortle.PlayerMarker.Entity
 	/// <summary>
 	/// An entity that is rendered above the player's head.
 	/// </summary>
-	internal class PlayerMarker : IEntity
+	internal sealed class PlayerMarker : IEntity, IDisposable
 	{
+		private static readonly Logger Logger = Logger.GetLogger(typeof(PlayerMarker));
+
 		private readonly VertexPositionColorTexture[] _vertex;
 
 		private ITexture _markerTexture;
+		private BasicEffect _effect;
+		private VertexBuffer _buffer;
 
 		/// <summary>
 		/// The <see cref="PlayerMarker"/>'s texture.
@@ -76,6 +80,17 @@ namespace Tortle.PlayerMarker.Entity
 			_vertex = new VertexPositionColorTexture[4];
 		}
 
+		public void Dispose()
+		{
+			Logger.Debug("Disposing");
+			_buffer?.Dispose();
+			_buffer = null;
+			_effect?.Dispose();
+			_effect = null;
+			_markerTexture?.Dispose();
+			_markerTexture = null;
+		}
+
 		/// <summary>
 		/// Updates the marker's Size and Color.
 		/// </summary>
@@ -117,24 +132,27 @@ namespace Tortle.PlayerMarker.Entity
 			var rotationMatrix = Matrix.Multiply(rotationMatrixX, rotationMatrixZ);
 			var worldMatrix = Matrix.Multiply(rotationMatrix, translationMatrix);
 
-			var renderEffect = new BasicEffect(graphicsDevice)
+
+			_effect ??= new BasicEffect(graphicsDevice)
 			{
 				VertexColorEnabled = true,
 				TextureEnabled = true,
-				View = GameService.Gw2Mumble.PlayerCamera.View,
-				Projection = GameService.Gw2Mumble.PlayerCamera.Projection,
-				World = worldMatrix,
-				Texture = MarkerTexture.Get(),
-				Alpha = MarkerOpacity,
 			};
 
-			var geometryBuffer = new VertexBuffer(graphicsDevice, VertexPositionColorTexture.VertexDeclaration, 4,
+			_effect.View = GameService.Gw2Mumble.PlayerCamera.View;
+			_effect.Projection = GameService.Gw2Mumble.PlayerCamera.Projection;
+			_effect.World = worldMatrix;
+			_effect.Alpha = MarkerOpacity;
+			_effect.Texture = MarkerTexture.Get();
+
+
+			_buffer ??= new VertexBuffer(graphicsDevice, VertexPositionColorTexture.VertexDeclaration, 4,
 				BufferUsage.WriteOnly);
-			geometryBuffer.SetData(_vertex);
+			_buffer.SetData(_vertex);
 
-			graphicsDevice.SetVertexBuffer(geometryBuffer, 0);
+			graphicsDevice.SetVertexBuffer(_buffer, 0);
 
-			foreach (var pass in renderEffect.CurrentTechnique.Passes)
+			foreach (var pass in _effect.CurrentTechnique.Passes)
 			{
 				pass.Apply();
 			}

--- a/PlayerMarkerModule/PlayerMarkerModule.cs
+++ b/PlayerMarkerModule/PlayerMarkerModule.cs
@@ -90,6 +90,7 @@ namespace Tortle.PlayerMarker
 			_settingsView.Dispose();
 
 			GameService.Graphics.World.RemoveEntity(_playerMarker);
+			_playerMarker.Dispose();
 		}
 
 		private void NormalizeSettings()

--- a/PlayerMarkerModule/Services/MarkerTextureManager.cs
+++ b/PlayerMarkerModule/Services/MarkerTextureManager.cs
@@ -11,7 +11,7 @@ namespace Tortle.PlayerMarker.Services
 	/// <summary>
 	/// Manages player marker textures.
 	/// </summary>
-	internal class MarkerTextureManager : IDisposable
+	internal sealed class MarkerTextureManager : IDisposable
 	{
 		private static readonly Logger Logger = Logger.GetLogger(typeof(MarkerTextureManager));
 		private readonly Dictionary<string, ITexture> _textures;
@@ -127,14 +127,6 @@ namespace Tortle.PlayerMarker.Services
 
 		public void Dispose()
 		{
-			this.Dispose(true);
-			GC.SuppressFinalize(this);
-		}
-
-		protected virtual void Dispose(bool disposing)
-		{
-			if (!disposing) return;
-
 			Logger.Debug("Disposing {textureCount} entries", _textures.Count);
 
 			foreach (var item in _textures)

--- a/PlayerMarkerModule/Services/ModuleSettings.cs
+++ b/PlayerMarkerModule/Services/ModuleSettings.cs
@@ -11,7 +11,7 @@ namespace Tortle.PlayerMarker.Services
 	/// <summary>
 	/// Setting definitions and event handlers.
 	/// </summary>
-	internal class ModuleSettings : IDisposable
+	internal sealed class ModuleSettings : IDisposable
 	{
 		private static readonly Logger Logger = Logger.GetLogger(typeof(ModuleSettings));
 
@@ -68,14 +68,6 @@ namespace Tortle.PlayerMarker.Services
 
 		public void Dispose()
 		{
-			Dispose(true);
-			GC.SuppressFinalize(this);
-		}
-
-		protected virtual void Dispose(bool disposing)
-		{
-			if (!disposing) return;
-
 			Logger.Debug("Disposing");
 			Enabled.SettingChanged -= UpdateSettings_Enabled;
 			Size.SettingChanged -= UpdateSettings_Size;

--- a/PlayerMarkerModule/Views/SettingsView.cs
+++ b/PlayerMarkerModule/Views/SettingsView.cs
@@ -16,7 +16,7 @@ namespace Tortle.PlayerMarker.Views
 	/// <summary>
 	/// A custom view containing all configurable module settings.
 	/// </summary>
-	internal class SettingsView : View, IDisposable
+	internal sealed class SettingsView : View, IDisposable
 	{
 		private const int SliderWidth = 175;
 		private static readonly Logger Logger = Logger.GetLogger(typeof(SettingsView));
@@ -360,14 +360,6 @@ namespace Tortle.PlayerMarker.Views
 
 		public void Dispose()
 		{
-			Dispose(true);
-			GC.SuppressFinalize(this);
-		}
-
-		protected virtual void Dispose(bool disposing)
-		{
-			if (!disposing) return;
-
 			Logger.Debug("Disposing");
 			_panelBackgroundTexture?.Dispose();
 			_buttonDarkTexture?.Dispose();


### PR DESCRIPTION
Memory leak was caused by creating a new BasicEffect each render loop. This has now been cached via a nullish assignment. PlayerMarker is now Disposable, too.